### PR TITLE
Add a singleton-style feature to the "todolist" example.

### DIFF
--- a/examples/todolist/Cargo.toml
+++ b/examples/todolist/Cargo.toml
@@ -14,6 +14,7 @@ name = "uniffi_todolist"
 uniffi_macros = {path = "../../uniffi_macros"}
 uniffi = {path = "../../uniffi", features=["builtin-bindgen"]}
 thiserror = "1.0"
+lazy_static = "1.4"
 
 [build-dependencies]
 uniffi_build = {path = "../../uniffi_build", features=["builtin-bindgen"]}

--- a/examples/todolist/src/todolist.udl
+++ b/examples/todolist/src/todolist.udl
@@ -1,4 +1,7 @@
 namespace todolist {
+    TodoList? get_default_list();
+    undefined set_default_list(TodoList list);
+
     [Throws=TodoError]
     TodoEntry create_entry_with(string todo);
 };
@@ -31,4 +34,6 @@ interface TodoList {
     string get_first();
     [Throws=TodoError]
     void clear_item(string todo);
+    [ByArc]
+    undefined make_default();
 };

--- a/examples/todolist/tests/bindings/test_todolist.py
+++ b/examples/todolist/tests/bindings/test_todolist.py
@@ -23,3 +23,24 @@ assert(todo.get_last() == "Test Ünicode hàndling without an entry can't believ
 entry2 = TodoEntry("Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
 todo.add_entry(entry2)
 assert(todo.get_last_entry().text == "Test Ünicode hàndling in an entry can't believe I didn't test this at first 🤣")
+
+todo2 = TodoList()
+assert(todo != todo2)
+assert(todo is not todo2)
+
+assert(get_default_list() is None)
+
+set_default_list(todo)
+assert(get_default_list() is todo)
+assert(get_default_list() is not todo2)
+
+todo2.make_default()
+assert(get_default_list() is not todo)
+assert(get_default_list() is todo2)
+
+todo.add_item("Test liveness after being demoted from default")
+assert(todo.get_last() == "Test liveness after being demoted from default")
+
+todo2.add_item("Test shared state through local vs default reference")
+assert(get_default_list().get_last() == "Test shared state through local vs default reference")
+

--- a/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
+++ b/uniffi_bindgen/src/bindings/python/templates/RustBufferStream.py
@@ -107,7 +107,7 @@ class RustBufferStream(object):
     # The Object type {{ object_name }}.
 
     def read{{ canonical_type_name }}(self):
-        handle = self.readU64();
+        handle = self._unpack_from(8, ">Q")
         return {{ object_name|class_name_py }}._get_or_make_instance_(handle)
 
     {% when Type::CallbackInterface with (object_name) -%}

--- a/uniffi_bindgen/src/interface/function.rs
+++ b/uniffi_bindgen/src/interface/function.rs
@@ -112,9 +112,6 @@ impl APIConverter<Function> for weedle::namespace::NamespaceMember<'_> {
 impl APIConverter<Function> for weedle::namespace::OperationNamespaceMember<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Function> {
         let return_type = ci.resolve_return_type_expression(&self.return_type)?;
-        if let Some(Type::Object(_)) = return_type {
-            bail!("Objects cannot currently be returned from functions");
-        }
         Ok(Function {
             name: match self.identifier {
                 None => bail!("anonymous functions are not supported {:?}", self),
@@ -180,9 +177,6 @@ impl APIConverter<Argument> for weedle::argument::Argument<'_> {
 impl APIConverter<Argument> for weedle::argument::SingleArgument<'_> {
     fn convert(&self, ci: &mut ComponentInterface) -> Result<Argument> {
         let type_ = ci.resolve_type_expression(&self.type_)?;
-        if let Type::Object(_) = type_ {
-            bail!("Objects cannot currently be passed as arguments");
-        }
         let default = match self.default {
             None => None,
             Some(v) => Some(convert_default_value(&v.value, &type_)?),


### PR DESCRIPTION
This is a nice little example of how to use object references,
and also happens to help us test a way that we want to use them
in a real consumer.

@mhammond r?